### PR TITLE
Add support for Beam state machines ADAR300x

### DIFF
--- a/+adi/+internal/ADAR300x.m
+++ b/+adi/+internal/ADAR300x.m
@@ -16,6 +16,16 @@ classdef (Abstract) ADAR300x < adi.common.Attribute & ...
         AmpENResetELV = [0, 0, 0, 0];
         AmpENSleepELH = [0, 0, 0, 0];
         AmpENSleepELV = [0, 0, 0, 0];
+        
+        BeamFIFORD = [0,0,0,0];
+        BeamFIFOWR = [0,0,0,0];
+        BeamRAMIndex = [0,0,0,0];
+        BeamRAMStart = [0,0,0,0];
+        BeamRAMStop = [0,0,0,0];
+        BeamRAMUpdate = [0,0,0,0];
+
+        BeamMode = {'direct','direct','direct','direct'};
+        BeamLoadMode = {'direct','direct','direct','direct'};
     end
     
     properties(Hidden, Constant)
@@ -387,6 +397,62 @@ classdef (Abstract) ADAR300x < adi.common.Attribute & ...
                     obj.AmpENSleepELV,obj.iioDevices);
             end
         end
+        % Check BeamMode
+        function set.BeamMode(obj, values)
+            attrs = {'beam0_mode','beam1_mode','beam2_mode',...
+                'beam3_mode'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices,'str');
+            end
+        end
+        % Check BeamLoadMode
+        function set.BeamLoadMode(obj, values)
+            attrs = {'beam0_load_mode','beam1_load_mode','beam2_load_mode',...
+                'beam3_load_mode'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices,'str');
+            end
+        end
+        % Check BeamFIFORD
+        function set.BeamFIFORD(obj, values)
+            attrs = {'beam0_fifo_rd','beam1_fifo_rd','beam2_fifo_rd',...
+                'beam3_fifo_rd'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices);
+            end
+        end
+        % Check BeamFIFOWR
+        function set.BeamFIFOWR(obj, values)
+            attrs = {'beam0_fifo_wr','beam1_fifo_wr','beam2_fifo_wr',...
+                'beam3_fifo_wr'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices);
+            end
+        end
+        % Check BeamRAMIndex
+        function set.BeamRAMIndex(obj, values)
+            attrs = {'beam0_ram_index','beam1_ram_index','beam2_ram_index',...
+                'beam3_ram_index'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices);
+            end
+        end
+        % Check BeamRAMStart
+        function set.BeamRAMStart(obj, values)
+            attrs = {'beam0_ram_start','beam1_ram_start','beam2_ram_start',...
+                'beam3_ram_start'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices);
+            end
+        end
+        % Check BeamRAMStop
+        function set.BeamRAMStop(obj, values)
+            attrs = {'beam0_ram_stop','beam1_ram_stop','beam2_ram_stop',...
+                'beam3_ram_stop'};
+            if obj.ConnectedToDevice
+                obj.setAllSingleDevAttrs(attrs,values,obj.iioDevices);
+            end
+        end
     end
     
     %% API Functions
@@ -445,7 +511,36 @@ classdef (Abstract) ADAR300x < adi.common.Attribute & ...
                             devices{deviceIndx});
                 end
             end           
-        end        
+        end
+        function values = getAllSingleDevAttrs(obj,attrs,devices,atype)
+            if nargin < 4
+                atype = 'int';
+            end
+            switch atype
+                case 'int'
+                    values = zeros(length(devices),length(attrs));
+                case 'str'
+                    values = cell(length(devices),length(attrs));                    
+            end
+            for deviceIndx=1:length(devices)
+                %DEBUG
+                if isempty(devices{deviceIndx})
+                    continue;
+                end
+                for attrsIndx = 1:length(attrs)
+                    switch atype
+                        case 'int'
+                            values(deviceIndx,attrsIndx) = ...
+                                obj.getDeviceAttributeLongLong(attrs{attrsIndx},...
+                                devices{deviceIndx});
+                        case 'str'
+                            values{deviceIndx,attrsIndx} = ...
+                                obj.getDeviceAttributeRAW(attrs{attrsIndx},...
+                                1024,devices{deviceIndx});
+                    end
+                end
+            end
+        end
     end
     
     methods (Hidden, Access = protected)
@@ -466,6 +561,31 @@ classdef (Abstract) ADAR300x < adi.common.Attribute & ...
         function [data,valid] = stepImpl(~)
             data = 0;
             valid = false;
+        end
+        function setAllSingleDevAttrs(obj,attrs,values,devices,atype)
+            assert(isequal([length(devices),length(attrs)],size(values)),...
+                sprintf('must of size [%dx%d]',length(devices),...
+                length(attrs)));
+            if nargin < 5
+                atype = 'int';
+            end
+
+            for deviceIndx=1:length(devices)
+                %DEBUG
+                if isempty(devices{deviceIndx})
+                    continue;
+                end
+                for attrsIndx = 1:length(attrs)
+                    switch atype
+                        case 'int'
+                            obj.setDeviceAttributeLongLong(attrs{attrsIndx},...
+                                values(deviceIndx,attrsIndx),devices{deviceIndx});
+                        case 'str'
+                            obj.setDeviceAttributeRAW(attrs{attrsIndx},...
+                                values{deviceIndx,attrsIndx},devices{deviceIndx});
+                    end
+                end
+            end
         end
         function setAllRelatedDevAttrs(obj,attrs,values,devices)
             

--- a/CI/scripts/rename_common.py
+++ b/CI/scripts/rename_common.py
@@ -1,0 +1,35 @@
+import os
+import glob
+import pathlib
+
+new_dir = "+commonrf"
+
+path = pathlib.Path(__file__).parent.resolve()
+
+path = os.path.split(path)
+path = os.path.split(path[0])[0]
+
+files = glob.glob(os.path.join(path, "+adi", "**/*"))
+if len(files) == 0:
+    print("No files found")
+    print("Did you clone all the submodules?")
+    exit(1)
+
+for file in files:
+    if os.path.isdir(file):
+        continue
+    with open(file, "r") as f:
+        content = f.read()
+    if "adi.common." in content:
+        content = content.replace("adi.common.", f"adi.{new_dir[1:]}.")
+        print("Updating:", file)
+        with open(file, "w") as f:
+            f.write(content)
+
+src = os.path.join(path, "+adi", "+common")
+dst = os.path.join(path, "+adi", new_dir)
+if os.path.isdir(src):
+    print("Renaming:", src, "->", dst)
+    os.rename(src, dst)
+else:
+    print("No +common folder found. Maybe you already renamed it?")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ stage("Build Toolbox") {
         withEnv(['PACKAGE='+branchName]) {
             checkout scm
             sh 'git submodule update --init'
+            sh 'python3 CI/scripts/rename_common.py'
             sh 'make -C ./CI/scripts gen_tlbx'
             archiveArtifacts artifacts: '*.mltbx'
             stash includes: '**', name: 'builtSources', useDefaultExcludes: false


### PR DESCRIPTION
PR adds beam controls for ADAR300x and associated tests. It also includes a fix to rename common core to commonrf to CI with a script.